### PR TITLE
Fix: Full message length on Message Signature

### DIFF
--- a/src/pages/Dashboard/widgets/SignMessage/components/SignSuccess.tsx
+++ b/src/pages/Dashboard/widgets/SignMessage/components/SignSuccess.tsx
@@ -11,8 +11,9 @@ const styles = {
   signatureContainer: 'signature-container flex flex-row w-full gap-2',
   signatureText: 'signature-text w-full resize-none outline-none bg-transparent',
   encodedMessageContainer: 'encoded-message-container flex flex-row w-full gap-2',
+  encodedMessageText: 'encoded-message-text flex-1 break-all',
   decodedMessageContainer: 'decoded-message-container flex flex-row w-full gap-2',
-  decodedMessageText: 'decoded-message-text resize-none outline-none text-green-700 bg-transparent'
+  decodedMessageText: 'decoded-message-text flex-1 break-all resize-none outline-none text-green-700 bg-transparent'
 } satisfies Record<string, string>;
 
 interface VerifyMessagePropsType {
@@ -51,20 +52,13 @@ export const SignSuccess = (props: VerifyMessagePropsType) => {
         <div className={styles.encodedMessageContainer}>
           <Label>Encoded message:</Label>
 
-          <p data-testid={DataTestIdsEnum.encodedMessage}>{encodedMessage}</p>
+          <p data-testid={DataTestIdsEnum.encodedMessage} className={styles.encodedMessageText}>{encodedMessage}</p>
         </div>
 
         <div className={styles.decodedMessageContainer}>
           <Label>Decoded message:</Label>
 
-          <textarea
-            data-testid={DataTestIdsEnum.decodedMessage}
-            readOnly
-            className={styles.decodedMessageText}
-            rows={1}
-            value={decodedMessage}
-            placeholder='Decoded message'
-          />
+          <p data-testid={DataTestIdsEnum.decodedMessage} className={styles.decodedMessageText}>{decodedMessage}</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Small change on the dApp Template so it displays the whole signed message once completed.

Previous version would cut the message short, giving the impression the message wasn't correctly/fully signed. 

Fix:
<img width="1313" height="605" alt="image" src="https://github.com/user-attachments/assets/c33f5906-9809-42e1-82f7-0951a61038dc" />

Previous:
<img width="1329" height="568" alt="image" src="https://github.com/user-attachments/assets/7dd7f983-8b81-4fee-baf3-2a0b941a3c87" />
