### PR TITLE
make left pannel scrollbar visible only when necessary

### DIFF
--- a/src/pages/Dashboard/components/LeftPanel/leftPanel.styles.ts
+++ b/src/pages/Dashboard/components/LeftPanel/leftPanel.styles.ts
@@ -1,6 +1,6 @@
 // prettier-ignore
 export default {
-  leftPanelContainer: 'left-panel-container flex flex-col w-screen lg:w-80 gap-8 lg:gap-0 py-4 p-6 sticky lg:h-screen top-0 bg-primary lg:bg-accent transition-all duration-200 ease-out overflow-y-scroll',
+  leftPanelContainer: 'left-panel-container flex flex-col w-screen lg:w-80 gap-8 lg:gap-0 py-4 p-6 sticky lg:h-screen top-0 bg-primary lg:bg-accent transition-all duration-200 ease-out overflow-y-auto',
   leftPanelContainerOpen: 'left-panel-container-open rounded-t-2xl lg:rounded-t-none p-6',
   leftPanelMobileHeader: 'left-panel-mobile-header flex lg:hidden justify-between items-center pt-2 pb-1 transition-all duration-200 ease-out',
   leftPanelMobileHeaderIconClose: 'left-panel-mobile-header-icon-close text-link transition-all duration-200 ease-out', 


### PR DESCRIPTION
Before: *scrollbar visible even when there is nothing to scroll
![Screenshot 2025-10-06 195158](https://github.com/user-attachments/assets/0d44db6b-bfed-464e-af21-ca2d5d2ef6f4)

After:
![Screenshot 2025-10-06 195522](https://github.com/user-attachments/assets/5017399d-11b7-42ae-95e6-c14c8d34100b)

it does not affect mobile view, and it shows the scroll bar only when the the window height is smaller than the container.